### PR TITLE
[bugfix] increase ncpu on OpenBSD

### DIFF
--- a/openbsd-6.0-amd64.json
+++ b/openbsd-6.0-amd64.json
@@ -103,7 +103,7 @@
   }],
   "variables": {
     "compression_level": "6",
-    "cpus": "1",
+    "cpus": "2",
     "disk_size": "40000",
     "headless": "false",
     "iso_checksum": "a9b6b812cb456f11ba4362e232efdd5f0c47868f4281e383ecee77541b54498c",

--- a/openbsd-6.1-amd64.json
+++ b/openbsd-6.1-amd64.json
@@ -106,7 +106,7 @@
   }],
   "variables": {
     "compression_level": "6",
-    "cpus": "1",
+    "cpus": "2",
     "disk_size": "40000",
     "headless": "false",
     "iso_checksum": "dfb4bf2408d993645ef9560e6913be48ca6e854322c42156954d4da93d450fd9",

--- a/openbsd-6.2-amd64.json
+++ b/openbsd-6.2-amd64.json
@@ -106,7 +106,7 @@
   }],
   "variables": {
     "compression_level": "6",
-    "cpus": "1",
+    "cpus": "2",
     "disk_size": "40000",
     "headless": "false",
     "iso_checksum": "b7994d29c7db3087db65158901d700fb7d10500b9b7496c1d86b285cabce0a2b",


### PR DESCRIPTION
the installer installs `bsd.mp` only when the detected ncpu upon boot is
more than 1. without this, SMP kernel would not be installed.