### PR TITLE
update to OpenBSD 6.3-beta

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,9 +38,9 @@ box:
     description: |
       * ansible version 2.4.3.0
   - name: openbsd-snapshot-amd64
-    version: 2017.02.21
+    version: 2017.03.09
     description: |
-      * update packages on 2017/02/21
+      * update packages on 2017/03/09
       * ansible version 2.4.3.0
   - name: centos-7.3-x86_64
     version: 1.2.1

--- a/openbsd-snapshot-amd64.json
+++ b/openbsd-snapshot-amd64.json
@@ -1,7 +1,7 @@
 {
   "builders": [{
     "type": "qemu",
-    "iso_url": "{{user `mirror`}}/snapshots/amd64/install62.iso",
+    "iso_url": "{{user `mirror`}}/snapshots/amd64/install63.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-openbsd-snapshot-amd64-{{build_type}}",
@@ -30,12 +30,12 @@
   }, {
     "type": "virtualbox-iso",
     "guest_os_type": "OpenBSD_64",
-    "iso_url": "{{user `mirror`}}/snapshots/amd64/install62.iso",
+    "iso_url": "{{user `mirror`}}/snapshots/amd64/install63.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-openbsd-snapshot-amd64-{{build_type}}",
     "vm_name": "packer-openbsd-snapshot-amd64",
-    "hard_drive_interface": "scsi",
+    "hard_drive_interface": "sata",
     "disk_size": "{{user `disk_size`}}",
     "headless": "{{user `headless`}}",
     "http_directory": "http",
@@ -62,7 +62,7 @@
   }, {
     "type": "vmware-iso",
     "guest_os_type": "freebsd-64",
-    "iso_url": "{{user `mirror`}}/snapshots/amd64/install62.iso",
+    "iso_url": "{{user `mirror`}}/snapshots/amd64/install63.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-openbsd-snapshot-amd64-{{build_type}}",
@@ -109,7 +109,7 @@
     "cpus": "2",
     "disk_size": "40000",
     "headless": "false",
-    "iso_checksum": "585c9e497e558cfd66945774cabc46a5334c63042dc450bbacd1bb370086b0cb",
+    "iso_checksum": "e34038fbea374936f36f4598654f2ea83aead3dc05775a62984548c3f36e48b2",
     "iso_checksum_type": "sha256",
     "memory": "512",
     "mirror": "https://fastly.cdn.openbsd.org/pub/OpenBSD",

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -92,9 +92,9 @@ when "openbsd"
   kern_version = Specinfra.backend.run_command("sysctl -n kern.version").stdout
   if os[:release].to_f >= 6.1
     describe command("syspatch -c") do
-      if kern_version =~ /-current/
+      if kern_version =~ /-(current|beta)/
         its(:exit_status) { should eq 1 }
-        its(:stderr) { should match(/^Unsupported release: \d+\.\d+-current/) }
+        its(:stderr) { should match(/^Unsupported release: \d+\.\d+-(current|beta)/) }
       else
         its(:exit_status) { should eq 0 }
         its(:stderr) { should eq "" }

--- a/ubuntu-16.04-amd64.json
+++ b/ubuntu-16.04-amd64.json
@@ -1,7 +1,7 @@
 {
   "builders": [{
     "type": "qemu",
-    "iso_url": "{{user `mirror`}}/16.04/ubuntu-16.04.5-server-amd64.iso",
+    "iso_url": "{{user `mirror`}}/16.04/ubuntu-16.04.4-server-amd64.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-ubuntu-16.04-amd64-{{build_type}}",
@@ -41,7 +41,7 @@
   }, {
     "type": "virtualbox-iso",
     "guest_os_type": "Ubuntu_64",
-    "iso_url": "{{user `mirror`}}/16.04/ubuntu-16.04.5-server-amd64.iso",
+    "iso_url": "{{user `mirror`}}/16.04/ubuntu-16.04.4-server-amd64.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-ubuntu-16.04-amd64-{{build_type}}",
@@ -82,7 +82,7 @@
   }, {
     "type": "vmware-iso",
     "guest_os_type": "ubuntu-64",
-    "iso_url": "{{user `mirror`}}/16.04/ubuntu-16.04.5-server-amd64.iso",
+    "iso_url": "{{user `mirror`}}/16.04/ubuntu-16.04.4-server-amd64.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-ubuntu-16.04-amd64-{{build_type}}",

--- a/ubuntu-16.04-amd64.json
+++ b/ubuntu-16.04-amd64.json
@@ -1,7 +1,7 @@
 {
   "builders": [{
     "type": "qemu",
-    "iso_url": "{{user `mirror`}}/16.04/ubuntu-16.04.3-server-amd64.iso",
+    "iso_url": "{{user `mirror`}}/16.04/ubuntu-16.04.5-server-amd64.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-ubuntu-16.04-amd64-{{build_type}}",
@@ -41,7 +41,7 @@
   }, {
     "type": "virtualbox-iso",
     "guest_os_type": "Ubuntu_64",
-    "iso_url": "{{user `mirror`}}/16.04/ubuntu-16.04.3-server-amd64.iso",
+    "iso_url": "{{user `mirror`}}/16.04/ubuntu-16.04.5-server-amd64.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-ubuntu-16.04-amd64-{{build_type}}",
@@ -82,7 +82,7 @@
   }, {
     "type": "vmware-iso",
     "guest_os_type": "ubuntu-64",
-    "iso_url": "{{user `mirror`}}/16.04/ubuntu-16.04.3-server-amd64.iso",
+    "iso_url": "{{user `mirror`}}/16.04/ubuntu-16.04.5-server-amd64.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "output-ubuntu-16.04-amd64-{{build_type}}",


### PR DESCRIPTION
also, use `sata` as a disk device due to crash on FeeBSD host. this change would be merged to other VMs if the issue happens while building them.